### PR TITLE
Fix non-existent keyword arguments in AdaScale/SpinQuant doc snippets

### DIFF
--- a/Docs/snippets/onnx/apply_adascale.py
+++ b/Docs/snippets/onnx/apply_adascale.py
@@ -69,7 +69,7 @@ quantsim = QuantizationSimModel(
     providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
 )
 # Setting kv_cache and some other layers to 8-bit
-_set_tensors_to_output_n_bit_symmmetric(quantsim, kv_bits=8)
+_set_tensors_to_output_n_bit_symmmetric(quantsim, 8)
 _set_lm_head_precision(quantsim, WeightPrecision(qtype=int8, granularity="PCQ"))
 _tie_quantizers_for_kv_cache(quantsim)
 
@@ -90,7 +90,7 @@ ADASCALE_NUM_ITERATIONS = 2048  # reduce for larger models; see quantization rec
 
 train_dataset = Wikitext.load_encoded_dataset(tokenizer, CONTEXT_LENGTH, "train")
 prefilled_inputs = _prefill_inputs(
-    quantsim, generator, train_dataset, num_batches=ADASCALE_NUM_BATCHES
+    quantsim, generator, train_dataset, ADASCALE_NUM_BATCHES
 )
 
 AdaScale.apply_adascale(
@@ -104,7 +104,7 @@ AdaScale.apply_adascale(
 # [compute-encodings]
 from tqdm import tqdm
 
-calib_inputs = _prefill_inputs(quantsim, generator, train_dataset, num_batches=20)
+calib_inputs = _prefill_inputs(quantsim, generator, train_dataset, 20)
 
 
 def _forward(session, _):

--- a/Docs/snippets/onnx/apply_spinquant.py
+++ b/Docs/snippets/onnx/apply_spinquant.py
@@ -68,7 +68,7 @@ quantsim = QuantizationSimModel(
     config_file="htp_v73",
     providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
 )
-_set_tensors_to_output_n_bit_symmmetric(quantsim, kv_bits=8)
+_set_tensors_to_output_n_bit_symmmetric(quantsim, 8)
 _set_lm_head_precision(quantsim, WeightPrecision(qtype=int8, granularity="PCQ"))
 _tie_quantizers_for_kv_cache(quantsim)
 
@@ -89,7 +89,7 @@ from GenAILab.bench.datasets import Wikitext
 from GenAILab.bench.onnx.quant_recipes import _prefill_inputs
 
 train_dataset = Wikitext.load_encoded_dataset(tokenizer, CONTEXT_LENGTH, "train")
-calib_inputs = _prefill_inputs(quantsim, generator, train_dataset, num_batches=20)
+calib_inputs = _prefill_inputs(quantsim, generator, train_dataset, 20)
 
 
 def _forward(session, _):

--- a/Docs/snippets/torch/apply_adascale.py
+++ b/Docs/snippets/torch/apply_adascale.py
@@ -59,7 +59,7 @@ ADASCALE_NUM_ITERATIONS = 2048  # reduce for larger models; see quantization rec
 
 train_dataset = Wikitext.load_encoded_dataset(tokenizer, CONTEXT_LENGTH, "train")
 prefilled_inputs = _prefill_inputs(
-    generator, train_dataset, num_batches=ADASCALE_NUM_BATCHES, device=torch.device("cpu")
+    generator, train_dataset, ADASCALE_NUM_BATCHES, torch.device("cpu")
 )
 
 apply_adascale(


### PR DESCRIPTION
Fixes #4112

## Problem

The Python snippets that `Docs/ptq_techniques/adascale.rst` and
`Docs/ptq_techniques/spinquant.rst` `literalinclude` pass keyword arguments that
do not exist on the functions they call, so every one of these calls raises
`TypeError` as soon as it is reached. The copy-paste flow the docs describe
cannot run.

| Callee | Actual signature | Snippet passes |
|---|---|---|
| `GenAILab/bench/onnx/quant_recipes.py:87` `_prefill_inputs` | `(quantsim, generator, dataloader, num_iterations=None)` | `num_batches=` |
| `GenAILab/bench/torch/quant_recipes.py:63` `_prefill_inputs` | `(generator, dataloader, num_iterations=None, device=None)` | `num_batches=` |
| `GenAILab/qai_hub_lm/backends/onnx/quantsim_utils.py:104` `_set_tensors_to_output_n_bit_symmmetric` | `(quantsim_model, n=8)` | `kv_bits=` |

Six call sites across three snippets are affected:
`Docs/snippets/onnx/apply_adascale.py:72,92,107`,
`Docs/snippets/onnx/apply_spinquant.py:71,92`,
`Docs/snippets/torch/apply_adascale.py:61`.

`kv_bits` / `num_batches` look like they were copied from the *local variable*
names at `GenAILab/bench/onnx/quant_recipes.py:314` and
`Examples/onnx/quantize.py:199`, where the value is passed **positionally**.

## Why positional rather than renaming to `num_iterations=` / `n=`

Every other caller in the repo passes these positionally:

- `GenAILab/bench/onnx/quant_recipes.py:274,314`
- `GenAILab/bench/torch/quant_recipes.py:243,270`
- `Examples/onnx/quantize.py:199,222,233`, `Examples/onnx/evaluate.py:126`
- `Examples/torch/quantize.py:230`

Positional also keeps the `num_batches` wording that `adascale.rst` uses in its
prose ("``ADASCALE_NUM_BATCHES`` and ``ADASCALE_NUM_ITERATIONS`` trade accuracy
against runtime") and in its recipe table's ``num_batches`` column, so no `.rst`
change is needed. Writing `num_iterations=ADASCALE_NUM_BATCHES` two lines above
`num_iterations=ADASCALE_NUM_ITERATIONS` (a different function's parameter)
would read as a contradiction. Happy to switch to explicit keywords if you'd
prefer.

## Verification

No AIMET runtime is needed: the three signatures were parsed out of their
defining modules with `ast`, rebuilt as stubs, and every call site replayed
through `inspect.Signature.bind`. The broken sites and the correct sibling sites
were run as one table, so the sibling group acts as a control:

```
PASS  BROKEN Docs/snippets/onnx/apply_adascale.py:72   -> TypeError: unexpected keyword 'kv_bits'
PASS  BROKEN Docs/snippets/onnx/apply_spinquant.py:71  -> TypeError: unexpected keyword 'kv_bits'
PASS  BROKEN Docs/snippets/onnx/apply_adascale.py:92   -> TypeError: unexpected keyword 'num_batches'
PASS  BROKEN Docs/snippets/onnx/apply_adascale.py:107  -> TypeError: unexpected keyword 'num_batches'
PASS  BROKEN Docs/snippets/onnx/apply_spinquant.py:92  -> TypeError: unexpected keyword 'num_batches'
PASS  BROKEN Docs/snippets/torch/apply_adascale.py:61  -> TypeError: unexpected keyword 'num_batches'
PASS  OK     Examples/onnx/quantize.py:199   (sibling, positional)   -> binds
PASS  OK     Examples/onnx/evaluate.py:126   (sibling, positional)   -> binds
PASS  OK     Examples/onnx/quantize.py:222   (sibling, positional)   -> binds
PASS  OK     test_adascale.py:1114           (sibling, num_iterations=) -> binds
PASS  OK     proposed fix (torch)                                    -> binds
mismatches: 0
```

After the patch, an AST pass that resolves cross-module imports and binds every
call site in the repo against its target signature reports **0** remaining
mismatches (it reported these 6 before).

## Scope

6 lines across 3 files, all under `Docs/snippets/`. No library code touched, no
`.rst` change needed. `Docs` is excluded from `.pre-commit-config.yaml`, so
`ruff-format` does not apply here; the edited lines stay within the existing
formatting. Commit is DCO-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
